### PR TITLE
Responsive Design InfoBanner

### DIFF
--- a/src/components/InfoBanner/InfoBanner.css
+++ b/src/components/InfoBanner/InfoBanner.css
@@ -1,39 +1,68 @@
 .info__banner {
-     padding-left: 20%;
-     padding-right: 20%;
-     padding-top: 1em;
-     padding-bottom: 1em;
-     display: flex;
-     justify-content: space-between;
-     align-items: center;
-     padding-left: 10%;
-     padding-right: 10%;
-     gap: 12em;
+    padding-left: 20%;
+    padding-right: 20%;
+    padding-top: 1em;
+    padding-bottom: 1em;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-left: 10%;
+    padding-right: 10%;
+    gap: 12em;
 }
 
 .info__banner__text {
-     display: flex;
-     flex-direction: column;
-     justify-content: center;
-     align-items: center;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
+.info__banner__text > p {
+    white-space: nowrap;
 }
 
 .info__stats {
-     height: 70px;
-     font-weight: 700;
-     font-size: 3vw;
-     line-height: 77px;
-     color: #EBE3E6;
-     margin-top: 0;
-     margin-bottom: 0;
+    height: 70px;
+    font-weight: 700;
+    font-size: 2.2em;
+    line-height: 77px;
+    color: #ebe3e6;
+    margin-top: 0;
+    margin-bottom: 0;
 }
 
 .info__header {
-     margin-bottom: 0;
-     margin-top: 0;
-     font-style: normal;
-     font-weight: 400;
-     font-size: 1.5vw;
-     line-height: 30px;
-     color: #FFFFFF;
+    margin-bottom: 0;
+    margin-top: 0;
+    font-style: normal;
+    font-weight: 400;
+    font-size: 1em;
+    line-height: 30px;
+    color: #ffffff;
+}
+
+@media screen and (max-width: 980px) {
+    .info__banner {
+        gap: 10em;
+    }
+    .info__stats {
+        font-size: 2em;
+    }
+    .info__header {
+        font-size: 0.8em;
+    }
+}
+
+@media screen and (max-width: 780px) {
+    .info__banner {
+        gap: 6em;
+    }
+}
+
+@media screen and (max-width: 650px) {
+    .info__banner {
+        flex-direction: column;
+        gap: 4em;
+    }
 }

--- a/src/components/InfoBanner/InfoBanner.css
+++ b/src/components/InfoBanner/InfoBanner.css
@@ -9,6 +9,7 @@
     padding-left: 10%;
     padding-right: 10%;
     gap: 12em;
+    font-size: 18px;
 }
 
 .info__banner__text {
@@ -64,5 +65,13 @@
     .info__banner {
         flex-direction: column;
         gap: 4em;
+    }
+}
+
+/* media queries for font size adjustments based on screen size */
+
+@media screen and (min-width: 1300px) {
+    .info__banner {
+        font-size: 25px;
     }
 }

--- a/src/components/InfoBanner/InfoBanner.jsx
+++ b/src/components/InfoBanner/InfoBanner.jsx
@@ -5,29 +5,35 @@ import { Center } from '@mantine/core';
 import CountUp from 'react-countup';
 
 const InfoBanner = () => {
-     return (
-          <section id="info-banner">    
-               <InfoDividerTop />
-               <Center style={{backgroundColor: "#12181B"}}>
-                    <div className="info__banner">
-                         <div className="info__banner__text">
-                              <p className="info__header"> Community of </p>
-                              <p className="info__stats">{<CountUp end={3000} duration={1.0} />}+</p>
-                              <p className="info__header"> CS Students </p>
-                         </div>
-                         <div className="info__banner__text">
-                              <p className="info__stats">{<CountUp end={20} duration={1.0} />}+</p>
-                              <p className="info__header"> Events in the Year </p>
-                         </div>
-                         <div className="info__banner__text">
-                              <p className="info__stats">{<CountUp end={52} duration={1.0} />}</p>
-                              <p className="info__header"> Executive Members </p>
-                         </div>
+    return (
+        <section id="info-banner">
+            <InfoDividerTop />
+            <Center style={{ backgroundColor: '#12181B' }}>
+                <div className="info__banner">
+                    <div className="info__banner__text">
+                        <p className="info__header"> Community of </p>
+                        <p className="info__stats">
+                            {<CountUp end={3000} duration={1.0} />}+
+                        </p>
+                        <p className="info__header"> CS Students </p>
                     </div>
-               </Center>
-               <InfoDividerBottom />
-          </section>
-     );
+                    <div className="info__banner__text">
+                        <p className="info__stats">
+                            {<CountUp end={20} duration={1.0} />}+
+                        </p>
+                        <p className="info__header"> Events in the Year </p>
+                    </div>
+                    <div className="info__banner__text">
+                        <p className="info__stats">
+                            {<CountUp end={52} duration={1.0} />}
+                        </p>
+                        <p className="info__header"> Executive Members </p>
+                    </div>
+                </div>
+            </Center>
+            <InfoDividerBottom />
+        </section>
+    );
 };
 
 export default InfoBanner;


### PR DESCRIPTION
Change the unit for the font size. They do not adjust depending on the screen size anymore. Difficult to manage in a flex box. We could however have media queries that would adjust the font sizes.

For example:

Since I am using `em` as the unit, everything is based on the `.info__banner` parent's font-size.

The initial font-size of the parent is `18px`, we can pump it up to `25px` for 2k+ screens.

```css
@media screen and (min-width: 2560px) {
    .info__banner {
         font-size: 25px;
    }
}
```