### PR TITLE
Feature/134/integration update firebase with notion events

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -2,5 +2,23 @@
   "firestore": {
     "rules": "./config/firestore.rules",
     "indexes": "./config/firestore.indexes.json"
+  },
+  "hosting": {
+    "public": "dist",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ]
+  },
+  "storage": {
+    "rules": "./config/storage.rules"
+  },
+  "functions": {
+    "source": "functions",
+    "predeploy": [
+      "npm --prefix \"$RESOURCE_DIR\" run lint",
+      "npm --prefix \"$RESOURCE_DIR\" run build"
+    ]
   }
 }

--- a/firebase.json
+++ b/firebase.json
@@ -2,32 +2,5 @@
   "firestore": {
     "rules": "./config/firestore.rules",
     "indexes": "./config/firestore.indexes.json"
-  },
-  "hosting": {
-    "public": "dist",
-    "ignore": [
-      "firebase.json",
-      "**/.*",
-      "**/node_modules/**"
-    ]
-  },
-  "storage": {
-    "rules": "./config/storage.rules"
-  },
-  "functions": [
-    {
-      "source": "functions",
-      "codebase": "default",
-      "ignore": [
-        "node_modules",
-        ".git",
-        "firebase-debug.log",
-        "firebase-debug.*.log"
-      ],
-      "predeploy": [
-        "npm --prefix \"$RESOURCE_DIR\" run lint",
-        "npm --prefix \"$RESOURCE_DIR\" run build"
-      ]
-    }
-  ]
+  }
 }

--- a/firebase.json
+++ b/firebase.json
@@ -13,5 +13,21 @@
   },
   "storage": {
     "rules": "./config/storage.rules"
-  }
+  },
+  "functions": [
+    {
+      "source": "functions",
+      "codebase": "default",
+      "ignore": [
+        "node_modules",
+        ".git",
+        "firebase-debug.log",
+        "firebase-debug.*.log"
+      ],
+      "predeploy": [
+        "npm --prefix \"$RESOURCE_DIR\" run lint",
+        "npm --prefix \"$RESOURCE_DIR\" run build"
+      ]
+    }
+  ]
 }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -68,7 +68,8 @@ export const scheduledSyncNotionEventsToFirestore = functions.pubsub.schedule('0
 				visible: page.properties["Visible"]?.multi_select.map((select: any) => select.name).join(", ") ?? true,
 			};
 
-			const docId = page.id.replace(/-/g, "");
+			const sanitizedTitle = title.replace(/\W+/g, "").toLowerCase(); // Remove non-alphanumeric characters and convert to lower case
+			const docId = `${sanitizedTitle}_${page.id.replace(/-/g, "").substring(0, 4)}`;
 
 			await db.collection("events").doc(docId).set(docData, { merge: true });
 		});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -39,6 +39,15 @@ export const scheduledSyncNotionEventsToFirestore = functions.pubsub.schedule('0
 				return;
 			}
 
+			const isInPersonOrOnline = page.properties["In Person/Online"]?.select?.name ?? null;
+			const hasConfirmedRoom = page.properties["Confirmed Room"]?.multi_select.length > 0;
+			//const hasTypeformSignIn = page.properties["Typeform Sign In"]?.url ?? null;
+			//const hasTypeformFeedback = page.properties["Typeform Feedback"]?.url ?? null;
+
+			if (!isInPersonOrOnline || !hasConfirmedRoom) {
+				return;
+			}
+
 			let description = "";
 
 			for (const block of blockResponse.results) {
@@ -69,7 +78,7 @@ export const scheduledSyncNotionEventsToFirestore = functions.pubsub.schedule('0
 			};
 
 			const sanitizedTitle = title.replace(/\W+/g, "").toLowerCase(); // Remove non-alphanumeric characters and convert to lower case
-			const docId = `${sanitizedTitle}_${page.id.replace(/-/g, "").substring(0, 4)}`;
+			const docId = `${sanitizedTitle}_${page.id.replace(/-/g, "").substring(0, 6)}`;
 
 			await db.collection("events").doc(docId).set(docData, { merge: true });
 		});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -62,7 +62,7 @@ export const scheduledSyncNotionEventsToFirestore = functions.pubsub.schedule('0
 				}
 			}
 
-			const title = page.properties["Name"]?.title[0]?.plain_text ?? "Untitled Event";
+			const title = page.properties["Name"]?.title[0]?.plain_text ?? "";
 			
 			if (!title) {
 			    return;

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -20,62 +20,62 @@ const notionClient = new NotionClient({
 
 //export const syncNotionEventsToFirestore = functions.https.onRequest(async (_, response) => {
 export const scheduledSyncNotionEventsToFirestore = functions.pubsub.schedule('0 * * * *').onRun(async (context) => {
-    try {
-        if (!databaseId) {
-            throw new Error("Environment variable NOTION_DATABASE_ID is not set.");
-        }
+	try {
+		if (!databaseId) {
+			throw new Error("Environment variable NOTION_DATABASE_ID is not set.");
+		}
 
-        const notionResponse = await notionClient.databases.query({ database_id: databaseId });
+		const notionResponse = await notionClient.databases.query({ database_id: databaseId });
 
 		notionResponse.results.forEach(async (page: any) => {
-		    const blockResponse = await notionClient.blocks.children.list({
-		        block_id: page.id,
-		    });
+			const blockResponse = await notionClient.blocks.children.list({
+				block_id: page.id,
+			});
 
-		    const date = page.properties["Date"]?.date?.start ?? "";
-		    const eventDate = date ? new Date(date) : null; 
+			const date = page.properties["Date"]?.date?.start ?? "";
+			const eventDate = date ? new Date(date) : null; 
 
-		    if (!eventDate || eventDate < new Date()) {
-		        return;
-		    }
+			if (!eventDate || eventDate < new Date()) {
+				return;
+			}
 
-		    let description = "";
+			let description = "";
 
 			for (const block of blockResponse.results) {
 
-			    if ('type' in block && block.type === "paragraph" && block.paragraph.rich_text.length > 0) {
+				if ('type' in block && block.type === "paragraph" && block.paragraph.rich_text.length > 0) {
 
-			        const firstNonEmptyParagraph = block.paragraph.rich_text.find(rt => rt.plain_text.trim() !== "");
-			        if (firstNonEmptyParagraph) {
-			            description = firstNonEmptyParagraph.plain_text;
-			            break; 
-			        }
-			    }
+					const firstNonEmptyParagraph = block.paragraph.rich_text.find(rt => rt.plain_text.trim() !== "");
+					if (firstNonEmptyParagraph) {
+						description = firstNonEmptyParagraph.plain_text;
+						break; 
+					}
+				}
 			}
 
-		    const title = page.properties["Name"]?.title[0]?.plain_text ?? "Untitled Event";
+			const title = page.properties["Name"]?.title[0]?.plain_text ?? "Untitled Event";
 
 			const docData = {
-			    title,
-			    date: eventDate,
-			    description,
-			    place: page.properties["Confirmed Room"]?.multi_select.map((select: any) => select.name).join(", ") ?? "",
-			    icon: page.icon.emoji ?? "✏️",
-			    igPost: "", // There's nothing on the notion, done manually? :(
-    			isPublicDate: page.properties["Date Public"]?.multi_select.map((select: any) => select.name).join(", ") ?? false,
-    			isPublicPlace: page.properties["Place Public"]?.multi_select.map((select: any) => select.name).join(", ") ?? false,
-    			isPublicTime: page.properties["Time Public"]?.multi_select.map((select: any) => select.name).join(", ") ?? false,
-    			visible: page.properties["Visible"]?.multi_select.map((select: any) => select.name).join(", ") ?? true,
+				title,
+				date: eventDate,
+				description,
+				place: page.properties["Confirmed Room"]?.multi_select.map((select: any) => select.name).join(", ") ?? "",
+				icon: page.icon.emoji ?? "✏️",
+				igPost: "", // There's nothing on the notion, done manually? :(
+				isPublicDate: page.properties["Date Public"]?.multi_select.map((select: any) => select.name).join(", ") ?? false,
+				isPublicPlace: page.properties["Place Public"]?.multi_select.map((select: any) => select.name).join(", ") ?? false,
+				isPublicTime: page.properties["Time Public"]?.multi_select.map((select: any) => select.name).join(", ") ?? false,
+				visible: page.properties["Visible"]?.multi_select.map((select: any) => select.name).join(", ") ?? true,
 			};
 
-		    const docId = page.id.replace(/-/g, "");
+			const docId = page.id.replace(/-/g, "");
 
-		    await db.collection("events").doc(docId).set(docData, { merge: true });
+			await db.collection("events").doc(docId).set(docData, { merge: true });
 		});
 		console.log("Notion events synced successfully with Firestore.");
-        //response.send("Notion events synced successfully with Firestore.");
-    } catch (error) {
-        console.error("Error syncing Notion events to Firestore:", error);
-        //response.status(500).send("Internal Server Error");
-    }
+		//response.send("Notion events synced successfully with Firestore.");
+	} catch (error) {
+		console.error("Error syncing Notion events to Firestore:", error);
+		//response.status(500).send("Internal Server Error");
+	}
 });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,7 +1,6 @@
 import * as functions from "firebase-functions";
 import * as admin from "firebase-admin";
 import { Client as NotionClient } from "@notionhq/client";
-import { v4 as uuidv4 } from 'uuid';
 
 admin.initializeApp();
 const db = admin.firestore();
@@ -19,7 +18,8 @@ const notionClient = new NotionClient({
 });
 
 
-export const syncNotionEventsToFirestore = functions.https.onRequest(async (_, response) => {
+//export const syncNotionEventsToFirestore = functions.https.onRequest(async (_, response) => {
+export const scheduledSyncNotionEventsToFirestore = functions.pubsub.schedule('0 * * * *').onRun(async (context) => {
     try {
         if (!databaseId) {
             throw new Error("Environment variable NOTION_DATABASE_ID is not set.");
@@ -54,7 +54,6 @@ export const syncNotionEventsToFirestore = functions.https.onRequest(async (_, r
 			}
 
 		    const title = page.properties["Name"]?.title[0]?.plain_text ?? "Untitled Event";
-		    const eventIdentifier = page.properties["Event Identifier"]?.rich_text[0]?.plain_text ?? ""
 
 			const docData = {
 			    title,
@@ -73,10 +72,10 @@ export const syncNotionEventsToFirestore = functions.https.onRequest(async (_, r
 
 		    await db.collection("events").doc(docId).set(docData, { merge: true });
 		});
-
-        response.send("Notion events synced successfully with Firestore.");
+		console.log("Notion events synced successfully with Firestore.");
+        //response.send("Notion events synced successfully with Firestore.");
     } catch (error) {
         console.error("Error syncing Notion events to Firestore:", error);
-        response.status(500).send("Internal Server Error");
+        //response.status(500).send("Internal Server Error");
     }
 });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -63,6 +63,10 @@ export const scheduledSyncNotionEventsToFirestore = functions.pubsub.schedule('0
 			}
 
 			const title = page.properties["Name"]?.title[0]?.plain_text ?? "Untitled Event";
+			
+			if (!title) {
+			    return;
+			}
 
 			const docData = {
 				title,

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,0 +1,120 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import { Client as NotionClient } from "@notionhq/client";
+import { v4 as uuidv4 } from 'uuid';
+
+admin.initializeApp();
+const db = admin.firestore();
+
+const notionSecret = process.env.NOTION_SECRET
+const databaseId = process.env.NOTION_DATABASE_ID
+
+
+if (!notionSecret || !databaseId) {
+  throw new Error("Environment variables for Notion are not set.");
+}
+
+const notionClient = new NotionClient({
+  auth: notionSecret,
+});
+
+export const setEventIDs = functions.https.onRequest(async (request, response) => {
+  try {
+    const entries = await notionClient.databases.query({
+      database_id: databaseId,
+    });
+
+    const updates = [];
+    for (const page of entries.results) {
+      if ('properties' in page) { 
+        const property = page.properties['Event Identifier']; 
+        if (property.type === "rich_text") { 
+          if (!property.rich_text || property.rich_text.length === 0) {
+
+            const newEventIdentifier = uuidv4();
+            updates.push(notionClient.pages.update({
+              page_id: page.id,
+              properties: {
+                'Event Identifier': {
+                  rich_text: [{
+                    type: 'text',
+                    text: { content: newEventIdentifier },
+                  }],
+                },
+              },
+            }));
+          }
+        }
+      }
+    }
+
+    await Promise.all(updates);
+
+    response.json({ message: 'Database updated successfully', updatedCount: updates.length });
+  } catch (error) {
+    console.error("Error updating Notion calendar:", error);
+    response.status(500).send("Internal Server Error");
+  }
+});
+
+
+
+export const syncNotionEventsToFirestore = functions.https.onRequest(async (_, response) => {
+    try {
+        if (!databaseId) {
+            throw new Error("Environment variable NOTION_DATABASE_ID is not set.");
+        }
+
+        const notionResponse = await notionClient.databases.query({ database_id: databaseId });
+
+		notionResponse.results.forEach(async (page: any) => {
+		    const blockResponse = await notionClient.blocks.children.list({
+		        block_id: page.id,
+		    });
+
+		    const date = page.properties["Date"]?.date?.start ?? "";
+		    const eventDate = date ? new Date(date) : null; 
+
+		    if (!eventDate || eventDate < new Date()) {
+		        return;
+		    }
+
+		    let description = "";
+
+			for (const block of blockResponse.results) {
+
+			    if ('type' in block && block.type === "paragraph" && block.paragraph.rich_text.length > 0) {
+
+			        const firstNonEmptyParagraph = block.paragraph.rich_text.find(rt => rt.plain_text.trim() !== "");
+			        if (firstNonEmptyParagraph) {
+			            description = firstNonEmptyParagraph.plain_text;
+			            break; 
+			        }
+			    }
+			}
+
+		    const title = page.properties["Name"]?.title[0]?.plain_text ?? "Untitled Event";
+		    const eventIdentifier = page.properties["Event Identifier"]?.rich_text[0]?.plain_text ?? ""
+
+			const docData = {
+			    title,
+			    date: eventDate,
+			    description,
+			    place: page.properties["Confirmed Room"]?.multi_select.map((select: any) => select.name).join(", ") ?? "",
+			    icon: page.icon.emoji ?? "✏️",
+			    igPost: "", // There's nothing on the notion, done manually? :(
+    			isPublicDate: page.properties["Date Public"]?.multi_select.map((select: any) => select.name).join(", ") ?? false,
+    			isPublicPlace: page.properties["Place Public"]?.multi_select.map((select: any) => select.name).join(", ") ?? false,
+    			isPublicTime: page.properties["Time Public"]?.multi_select.map((select: any) => select.name).join(", ") ?? false,
+    			visible: page.properties["Visible"]?.multi_select.map((select: any) => select.name).join(", ") ?? true,
+			};
+
+		    await db.collection("events").doc(eventIdentifier).set(docData, { merge: true });
+		});
+
+        response.send("Notion events synced successfully with Firestore.");
+    } catch (error) {
+        console.error("Error syncing Notion events to Firestore:", error);
+        response.status(500).send("Internal Server Error");
+    }
+});


### PR DESCRIPTION
🔄[Integration to Update Firebase with Events on Notion #134](https://github.com/LaurierCS/Website/issues/134)

🔍 **What's Included**
- Implemented an hourly events sync from Notion to Firebase, using Notion's page IDs as unique identifiers.

📁 Files Affected:
- `functions/src/index.ts`

📝 Notes:
- `isPublicDate`, `isPublicPlace`, `isPublicTime`, `igPost`, and `visible` fields don't exist on the Notion events, meaning they'll be overwritten by the hourly events sync when changed manually through Firestore.
   - If we decide to add the fields to the Notion event template directly to solve this issue, the code is already set up to accept those values 🤯
   - If changing the values manually in Firestore is still the play, we'll have to change the code to work around this 😞 