### PR TITLE
Fix/153/gradient-fix-to-match-figma

### DIFF
--- a/src/components/HeroSection/HeroSection.tsx
+++ b/src/components/HeroSection/HeroSection.tsx
@@ -73,7 +73,7 @@ const useStyles = createStyles((theme: MantineTheme) => ({
 const HeroSection: React.FC = () => {
     const { classes } = useStyles();
     return (
-        <section style={{ marginBottom: "-24rem" }} id="top">
+        <section style={{ marginBottom: "-20rem" }} id="top">
             <Container py="8rem" size="xl" my="md" className={classes.container}>
                 <Center style={{ width: "100%", height: "100%" }}>
                     <Flex

--- a/src/components/HeroSection/HeroSection.tsx
+++ b/src/components/HeroSection/HeroSection.tsx
@@ -73,7 +73,7 @@ const useStyles = createStyles((theme: MantineTheme) => ({
 const HeroSection: React.FC = () => {
     const { classes } = useStyles();
     return (
-        <section id="top">
+        <section style={{ marginBottom: "-24rem" }} id="top">
             <Container py="8rem" size="xl" my="md" className={classes.container}>
                 <Center style={{ width: "100%", height: "100%" }}>
                     <Flex

--- a/src/main.css
+++ b/src/main.css
@@ -4,9 +4,14 @@
 html, #root {
     background: var(--color-background-default);
 }
+#top {
+  background: #1A1B1E !important; /* Use !important to ensure override */
+}
 
 :root {
     --color-background-default: linear-gradient(180deg, #1A1B1E 0%, #1E2123 23.96%, #1B1F21 44.27%, #1D2A31 62.5%, #1D3847 81.25%, #235571 100%);
+    background-image: var(--color-background-default);
+    background-size: auto 2000%;
     --color-black:#000000;
     --color-white:#FFFFFF;
     --color-blue: #29ABF4;

--- a/src/main.css
+++ b/src/main.css
@@ -3,6 +3,8 @@
 
 html, #root {
     background: var(--color-background-default);
+    min-height: 100%;
+    height: auto;
 }
 #top {
   background: #1A1B1E !important; /* Use !important to ensure override */

--- a/src/main.css
+++ b/src/main.css
@@ -7,7 +7,7 @@ html, #root {
     height: auto;
 }
 #top {
-  background: #1A1B1E !important; /* Use !important to ensure override */
+  background: #1A1B1E !important;
 }
 
 :root {


### PR DESCRIPTION
🎨[[Bug] !Important - Gradient is broken #153](https://github.com/LaurierCS/Website/issues/153)

🔍 **What's Included**
- Adjusted the site's gradient so it stops repeating weirdly.
- Removed the Hero Section's gradient and moved stats bubble up to match Figma.

📁 Files Affected:
- `src/components/HeroSection/HeroSection.tsx`
- `src/main.css`